### PR TITLE
[ fix ] update brief

### DIFF
--- a/idris2-systemd.ipkg
+++ b/idris2-systemd.ipkg
@@ -2,7 +2,7 @@ package idris2-systemd
 version = 0.1.0
 authors = "Matthew Mosior"
 maintainers = "Matthew Mosior"
-brief = "A systemd library."
+brief = "A systemd library"
 homepage = "https://github.com/Matthew-Mosior/idris2-systemd"
 sourceloc = "https://github.com/Matthew-Mosior/idris2-systemd/tree/main/src"
 bugtracker = "https://github.com/Matthew-Mosior/idris2-systemd/issues"


### PR DESCRIPTION
This PR remove unnecessary punctuation from the `brief` field of the `ipkg` file.