### PR TITLE
[ fix ] Add license field to `.ipkg`

### DIFF
--- a/idris2-systemd.ipkg
+++ b/idris2-systemd.ipkg
@@ -1,6 +1,7 @@
 package idris2-systemd
 version = 0.1.0
 authors = "Matthew Mosior"
+license = "BSD-3 Clause"
 maintainers = "Matthew Mosior"
 brief = "A systemd library"
 homepage = "https://github.com/Matthew-Mosior/idris2-systemd"


### PR DESCRIPTION
This PR adds the `license` field to the `.ipkg` file.