### PR TITLE
[ refactor ] refactor primitive naming

### DIFF
--- a/src/System/Systemd/Internal.idr
+++ b/src/System/Systemd/Internal.idr
@@ -13,7 +13,7 @@ import System.Posix.Socket
 --------------------------------------------------------------------------------
 
 export %foreign "C:sd_notify_with_fd,systemd-idris"
-sd_notify_with_fd : Int -> String -> Bits64 -> AnyPtr -> Bits32 -> Int -> PrimIO Int
+prim__sdNotifyWithFd : Int -> String -> Bits64 -> AnyPtr -> Bits32 -> Int -> PrimIO Int
 
 --------------------------------------------------------------------------------
 --          Internal utilities
@@ -40,12 +40,12 @@ private
 sendBufWithFdTo : Socket AF_UNIX -> String -> SockaddrUn -> Fd -> IO Int
 sendBufWithFdTo socket state socketaddress filedesc =
   primIO $
-    sd_notify_with_fd (cast {to=Int} $ fd $ cast {to=Fd} socket)
-                      state
-                      (cast {to=Bits64} (strLength state))
-                      (ptr AF_UNIX socketaddress)
-                      (addrSize AF_UNIX)
-                      (cast {to=Int} (fd filedesc))
+    prim__sdNotifyWithFd (cast {to=Int} $ fd $ cast {to=Fd} socket)
+                         state
+                         (cast {to=Bits64} (strLength state))
+                         (ptr AF_UNIX socketaddress)
+                         (addrSize AF_UNIX)
+                         (cast {to=Int} (fd filedesc))
 
 export
 notifyWithFd_ : Bool -> String -> Maybe Fd -> IO (Maybe ())


### PR DESCRIPTION
This PR refactors the C primitive function `sd_notify_with_fd` by renaming and adding the `prim__` prefix.